### PR TITLE
add BASE_PATH configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,9 @@ Docker image for [NetBox][gh-nb].
 
 NetBox will be available under port 8000.
 
+## Additional configuration
+
+* `BASE_PATH`: set this if netbox is running behind a reverse proxy and you need the URL to be rewritten, for example if you want to reach your netbox via example.com/netbox/, set BASE_PATH='netbox/'
 
 [gh-nb]: https://github.com/digitalocean/netbox
 [gh-nb-secret-key]: https://github.com/digitalocean/netbox/blob/8563e2aca30fd160b62bbf1f734b2b3b0cf24cfe/docs/configuration.md#secret_key

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -51,7 +51,7 @@ initialize_config() {
     sed -i "/^LOGIN_REQUIRED = /c\\LOGIN_REQUIRED = $LOGIN_REQUIRED" configuration.py
 
     # Base path
-    sed -i "/^BASE_PATH = /c\\BASE_PATH = $BASE_PATH" configuration.py
+    sed -i "/^BASE_PATH = /c\\BASE_PATH = '$BASE_PATH'" configuration.py
 
     popd 2>&1 > /dev/null
 }

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -16,6 +16,8 @@ setup_environment_variables() {
 
     LOGIN_REQUIRED=${LOGIN_REQUIRED:-False}
 
+    BASE_PATH=${BASE_PATH:-''}
+
     : "${SECRET_KEY:?SECRET_KEY needs to be set}"
 }
 
@@ -47,6 +49,9 @@ initialize_config() {
 
     # Login required
     sed -i "/^LOGIN_REQUIRED = /c\\LOGIN_REQUIRED = $LOGIN_REQUIRED" configuration.py
+
+    # Base path
+    sed -i "/^BASE_PATH = /c\\BASE_PATH = $BASE_PATH" configuration.py
 
     popd 2>&1 > /dev/null
 }


### PR DESCRIPTION
Hello,

We need to run netbox behind a reverse proxy, where URL rewriting is used. That is why we need to set the BASE_PATH configuration, which was missing so far, so I made this small addition and I think this might be useful for others too.

Regards,
Kevin