### PR TITLE
Add --noreload to command in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,4 +30,4 @@ RUN chmod 755 /sbin/entrypoint.sh
 EXPOSE 8000/tcp
 
 ENTRYPOINT ["/sbin/entrypoint.sh"]
-CMD ["runserver", "--insecure", "0.0.0.0:8000"]
+CMD ["runserver", "--noreload", "--insecure", "0.0.0.0:8000"]


### PR DESCRIPTION
Added --noreload to command in Dockerfile.

When running Django applications through manage.py they will constantly monitor the underlying filesystem for changes. This is useful in development environments but not so much when running in production. Adding the --noreload parameter reduces CPU usage considerably.